### PR TITLE
Remove duplicate configuration entries in wg0.config

### DIFF
--- a/src/lib/WireGuard.js
+++ b/src/lib/WireGuard.js
@@ -136,15 +136,6 @@ H1 = ${config.server.h1}
 H2 = ${config.server.h2}
 H3 = ${config.server.h3}
 H4 = ${config.server.h4}
-Jc = ${config.server.jc}
-Jmin = ${config.server.jmin}
-Jmax = ${config.server.jmax}
-S1 = ${config.server.s1}
-S2 = ${config.server.s2}
-H1 = ${config.server.h1}
-H2 = ${config.server.h2}
-H3 = ${config.server.h3}
-H4 = ${config.server.h4}
 `;
 
     for (const [clientId, client] of Object.entries(config.clients)) {


### PR DESCRIPTION
Duplicate configuration parameters were removed from the WireGuard configuration file. While these duplicates do not affect the functionality of the VPN, their presence was unnecessary and could lead to confusion. 